### PR TITLE
Password was not interpolated in WHERE clause

### DIFF
--- a/core/Authentication.php
+++ b/core/Authentication.php
@@ -14,7 +14,7 @@ class Authentication {
      */
     public function login($username, $password) {
         $user = new UsersRepository();
-        $where = "username = '{$username}' && password = '$password'";
+        $where = "username = '{$username}' && password = '{$password}'";
         $result = $user->get($where);
         if ($result) {
             $_SESSION["user-status"] = 1;


### PR DESCRIPTION
Authentication will fail because it would not consider user's password. Fixed this by interpolating password in WHERE clause.